### PR TITLE
Fixed methodName for SubtleAlert

### DIFF
--- a/src/js/Controllers/UIController.js
+++ b/src/js/Controllers/UIController.js
@@ -704,7 +704,7 @@ class UIController {
         if (ttsController.isAlertSpeakInProgress()) {
             clearTimeout(this.timers[msgID]);
             this.timers[msgID] = setTimeout(this.onAlertTimeout, 1000, msgID, appID, context, isSubtle);
-            this.listener.send(RpcFactory.OnResetTimeout(msgID,'UI.Alert',1000));
+            this.listener.send(RpcFactory.OnResetTimeout(msgID, isSubtle ? "UI.SubtleAlert" : "UI.Alert",1000));
             return;
         }
 


### PR DESCRIPTION
Task:
[1097](https://luxproject.luxoft.com/jira/browse/AAW-1097) [Generic HMI] HMI sends wrong methoName in BC.OnResetTimeout notification during SubtleAlert RPC processing 
