### PR TITLE
Changed messagecode for ActivateApp for revoked app

### DIFF
--- a/src/js/Controllers/SDLController.js
+++ b/src/js/Controllers/SDLController.js
@@ -202,7 +202,7 @@ class SDLController {
                         return app.appID === activatingApplication;
                     });
                     var revokedAppName = revokedApp ? revokedApp.appName : 'App';
-                    this.getUserFriendlyMessage([ "AppUnsupported" ], (response) => {
+                    this.getUserFriendlyMessage([ "AppUnauthorized" ], (response) => {
                         var heading = 'App is revoked';
                         var body = `${revokedAppName} does not have permission to run`;
                         if (response.result.messages && response.result.messages.length === 1) {


### PR DESCRIPTION
Fixes #[12619](https://adc.luxoft.com/jira/browse/FORDTCN-12619)


### Summary
Message with AppUnauthorized code is more obvious for users when application is revoked.

