### PR TITLE
Fixed issue: HMI sends error DecryptCertificate("success": false) response in case PTU contains decrypted certificate

### DIFF
--- a/tools/start_server.py
+++ b/tools/start_server.py
@@ -338,6 +338,8 @@ class RPCService(WSServer.SampleRPCService):
     private_key = None
     try:
       file_contents = open(crt_file_path, 'rb').read()
+      if b"BEGIN CERTIFICATE" in file_contents:
+        return { 'success': True }
       p12 = crypto.load_pkcs12(base64.b64decode(file_contents),
         Flags.CERT_PASS_PHRASE.encode('utf-8'))
       certificate = p12.get_certificate()


### PR DESCRIPTION
Fixes [#AAW-1171](https://luxproject.luxoft.com/jira/browse/AAW-1171)

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

### Summary
Added check file content `BEGIN CERTIFICATE` substring is exist.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
