### PR TITLE
Fix React className warnings

### DIFF
--- a/src/img/dynamic/IconSeekLeftWithText.js
+++ b/src/img/dynamic/IconSeekLeftWithText.js
@@ -8,9 +8,9 @@ export default class IconSeekLeftWithText extends React.Component {
             <path d="M49,39l-1.4-1.4C50.4,34.8,52,31,52,27c0-4-1.5-7.8-4.4-10.6S41,12.1,37,12.1c-4,0-7.8,1.5-10.6,4.4
                 C21.1,21.8,20.5,30,25,36l-1.6,1.2C18.3,30.4,18.9,21.1,25,15c3.2-3.2,7.5-4.9,12-4.9c4.6,0,8.8,1.8,12,4.9c3.2,3.2,4.9,7.5,4.9,12
                 C54,31.6,52.2,35.8,49,39z"/>
-            <polyline class="svg-fill-important" points="19,37 25.2,38.8 27,33 "/>
+            <polyline className="svg-fill-important" points="19,37 25.2,38.8 27,33 "/>
             <text transform="matrix(1.5 0 0 1.5 28 32)" style={{fontFamily : "Arial-BoldMT", fontSize : 12}} 
-                class="svg-stroke">{this.props.seekTime}</text>
+                className="svg-stroke">{this.props.seekTime}</text>
             </svg>
         )
     }

--- a/src/img/dynamic/IconSeekRightWithText.js
+++ b/src/img/dynamic/IconSeekRightWithText.js
@@ -8,9 +8,9 @@ export default class IconSeekRightWithText extends React.Component {
             <path d="M20.1,27c0-4.5,1.7-8.8,4.9-12c3.2-3.1,7.4-4.9,12-4.9c4.5,0,8.8,1.7,12,4.9c6.1,6.1,6.7,15.4,1.6,22.2L49,36
                 c4.5-6,3.9-14.2-1.4-19.5c-2.8-2.9-6.6-4.4-10.6-4.4s-7.7,1.5-10.6,4.3S22,23,22,27s1.6,7.8,4.4,10.6L25,39
                 C21.8,35.8,20,31.6,20.1,27z"/>
-            <polyline class="svg-fill-important" points="47,33 48.8,38.8 55,37 "/>
+            <polyline className="svg-fill-important" points="47,33 48.8,38.8 55,37 "/>
             <text transform="matrix(1.5 0 0 1.5 28 32)" style={{fontFamily : "Arial-BoldMT", fontSize : 12}} 
-                class="svg-stroke">{this.props.seekTime}</text>
+                className="svg-stroke">{this.props.seekTime}</text>
             </svg>
         )
     }

--- a/src/js/AppPermissions.js
+++ b/src/js/AppPermissions.js
@@ -75,11 +75,11 @@ class Permissions extends React.Component {
                 <div className="vscrollmenu-item th-b-color th-bb-color-secondary" key={f.id}
                     onClick={(e) => this.toggleFunction(f.name)} style={{ height: 'auto' }}>
                     <div className={"vscrollmenu-item__primary th-f-color"}>
-                        <div class="form-check form-switch permissionsToggle">
-                            <input class="form-check-input" type="checkbox" checked={f.allowed} style={{ width: '5em' }} />
+                        <div className="form-check form-switch permissionsToggle">
+                            <input className="form-check-input" type="checkbox" checked={f.allowed} style={{ width: '5em' }} />
                         </div>
                         <div className={"vscrollmenu-item__name th-f-color"} style={{ marginRight: '2%' }}>
-                            <p class="t-large t-light th-f-color">{f.title || f.name}</p>
+                            <p className="t-large t-light th-f-color">{f.title || f.name}</p>
                             <p className="t-small t-light th-f-color-secondary">{f.body}</p>
                         </div>
                     </div>

--- a/src/js/PermissionAppList.js
+++ b/src/js/PermissionAppList.js
@@ -27,7 +27,7 @@ class Permissions extends React.Component {
                     theme={this.props.theme}
                 />
                 <div className="vscrollmenu-item__primary th-f-color" style={{ marginLeft: '2%' }}>
-                    <p class="t-large t-light th-f-color">{app.appName} Permissions</p>
+                    <p className="t-large t-light th-f-color">{app.appName} Permissions</p>
                 </div>
             </div>;
         });

--- a/src/js/Settings.js
+++ b/src/js/Settings.js
@@ -108,7 +108,7 @@ class Settings extends React.Component {
         return (
             <div>
                 <AppHeader backLink="/" menuName="Apps" icon="false" title="Settings"/>
-                <div class="hscrollmenu">
+                <div className="hscrollmenu">
                     {settingsButtons}
                 </div>
             </div>

--- a/src/js/VScrollMenuItem.js
+++ b/src/js/VScrollMenuItem.js
@@ -41,7 +41,7 @@ export default class VScrollMenuItem extends React.Component {
                         <p className="t-large t-light th-f-color">{this.props.menuItem.name}</p>
                         <p className="t-small t-light th-f-color-secondary">{secondaryText}</p>
                     </div>
-                    <div class="vscrollmenu-item__image mw-100px">
+                    <div className="vscrollmenu-item__image mw-100px">
                         <SoftButtonImage 
                             image={this.props.menuItem.secondaryImage ? this.props.menuItem.secondaryImage.value : null} 
                             imageType={this.props.menuItem.secondaryImage ? this.props.menuItem.secondaryImage.imageType : null}


### PR DESCRIPTION


### Summary
Fix React warnings by replacing `class` with `className`